### PR TITLE
Fix versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,3 @@
 [
-  {
-    "required_api_version": "^2.0.0",
-    "commit": "release-for-api-v2"
-  },
-  {
-    "required_api_version": "^2.3.1",
-    "commit": "main"
-  }
+  { "required_api_version": "^2.0.0", "commit": "main" }
 ]


### PR DESCRIPTION
The versions.json refers to a non-existing-branch "release-for-api-v2" and a non-existing api verion 2.3.1. This prevents a fresh install of the extension.
This little change to versions.json allows the extension to be installed again. Thanks btw, great simple extension without external deps, I like it!

Fixes #1 